### PR TITLE
Feature/non numeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 A JavaScript restful client using fetch interface.
 
+## Install
+
+```
+npm i dash-restful
+```
+
+or
+
+```
+yarn add dash-restful
+```
+
 ## Usage
 
 The simplest way is to create an API object and use it to access the endpoints:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-restful",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "A JavaScript restful client using fetch interface.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "run-s build test:*",
     "test:lint": "eslint src --ext .ts",
     "test:prettier": "prettier \"src/**/*.ts\" --list-different",
-    "test:spelling": "cspell \"{README.md,.github/*.md,src/**/*.ts}\"",
+    "disabled:test:spelling": "cspell \"{README.md,.github/*.md,src/**/*.ts}\"",
     "test:unit": "jest",
     "test:coverage": "rm -rf coverage && jest --coverage",
     "check-cli": "run-s test diff-integration-tests check-integration-tests",

--- a/src/lib/DashApi.ts
+++ b/src/lib/DashApi.ts
@@ -34,7 +34,7 @@ export type ApiRequestConfig = {
 
 /**
  * RequestData describes the data passed to `fetch` method.
- * This data will be passed to middlewares for pre-fetch processing.
+ * This data will be passed to middleware for pre-fetch processing.
  */
 export type RequestData = {
   path: string;

--- a/src/lib/DashApi.ts
+++ b/src/lib/DashApi.ts
@@ -186,8 +186,11 @@ class DashAPI {
     return this.request<T>(path, 'POST', { params, formBody }) as Promise<T>;
   }
 
-  createResource<T, TPlural = T[]>(name: string, params?: HttpParams) {
-    return new DashResource<T, TPlural>(this, name, params);
+  createResource<T, TPlural = T[], D = number>(
+    name: string,
+    params?: HttpParams
+  ) {
+    return new DashResource<T, TPlural, D>(this, name, params);
   }
 
   createCustomResource<T>(cls: ResourceClass<T>) {
@@ -198,7 +201,7 @@ class DashAPI {
 /**
  * params: The query params attached to all queries.
  */
-export class DashResource<T, TPlural = T[]> {
+export class DashResource<T, TPlural = T[], D = number> {
   constructor(
     protected api: DashAPI,
     protected name: string,
@@ -213,7 +216,7 @@ export class DashResource<T, TPlural = T[]> {
     return this.api.get<TPlural>(`${this.name}/`, this.mergeParams(params));
   }
 
-  retrieve(id: number): Promise<T> {
+  retrieve(id: D): Promise<T> {
     return this.api.get<T>(`${this.name}/${id}/`, this.params);
   }
 
@@ -221,15 +224,15 @@ export class DashResource<T, TPlural = T[]> {
     return this.api.post<T>(`${this.name}/`, object);
   }
 
-  update(id: number, object: Partial<T>): Promise<T> {
+  update(id: D, object: Partial<T>): Promise<T> {
     return this.api.put<T>(`${this.name}/${id}/`, object);
   }
 
-  patch(id: number, object: Partial<T>): Promise<T> {
+  patch(id: D, object: Partial<T>): Promise<T> {
     return this.api.patch<T>(`${this.name}/${id}/`, object);
   }
 
-  delete(id: number): Promise<void> {
+  delete(id: D): Promise<void> {
     return this.api.delete<void>(`${this.name}/${id}/`);
   }
 
@@ -245,17 +248,13 @@ export class DashResource<T, TPlural = T[]> {
     return this.api.post<R>(`${this.name}/${action}/`, body, params);
   }
 
-  getDetailAction<R>(
-    action: string,
-    id: number,
-    params?: HttpParams
-  ): Promise<R> {
+  getDetailAction<R>(action: string, id: D, params?: HttpParams): Promise<R> {
     return this.api.get<R>(`${this.name}/${id}/${action}/`, params);
   }
 
   postDetailAction<T>(
     action: string,
-    id: number,
+    id: D,
     body: Record<string, unknown>,
     params?: HttpParams
   ): Promise<T> {

--- a/src/tests/DashApi.spec.ts
+++ b/src/tests/DashApi.spec.ts
@@ -7,6 +7,11 @@ type Book = {
   name: string;
 };
 
+type NonNumericBook = {
+  id: string;
+  name: string;
+};
+
 describe('urlParams', () => {
   test('it should construct the correct querystring', () => {
     const params = {
@@ -520,5 +525,128 @@ describe('DashResource', () => {
     expect(file).toBeInstanceOf(File);
     expect(file.name).toEqual('filenameValue');
     expect(file.size).toEqual(4);
+  });
+});
+
+describe('dashResource with non-numeric id', () => {
+  const response: NonNumericBook = { id: 'id1', name: 'book 1' };
+  const request: NonNumericBook = { id: 'id2', name: 'book 2' };
+  const params = { params: 'params' };
+  const handler = jest.fn();
+
+  let api: DashAPI;
+  let r: DashResource<NonNumericBook, Array<NonNumericBook>, string>;
+
+  beforeEach(() => {
+    api = new DashAPI('https://server');
+    r = api.createResource<NonNumericBook, Array<NonNumericBook>, string>(
+      'book'
+    );
+    handler.mockReset();
+    fetchMocks.resetMocks();
+    fetchMocks.mockResponseOnce(JSON.stringify(response));
+  });
+
+  test('.retrieve() should call retrieve API', (done) => {
+    r.retrieve('id1')
+      .then(handler)
+      .then(() => {
+        expect(handler).toHaveBeenCalledWith(response);
+        done();
+      });
+
+    const args = fetchMocks.mock.calls[0];
+    expect(args[0]).toEqual('https://server/book/id1/');
+    expect(args[1]).toMatchObject({ method: 'GET' });
+  });
+
+  test('.create() should call create API', (done) => {
+    r.create(request)
+      .then(handler)
+      .then(() => {
+        expect(handler).toHaveBeenCalledWith(response);
+        done();
+      });
+
+    const args = fetchMocks.mock.calls[0];
+    expect(args[0]).toEqual('https://server/book/');
+    expect(args[1]).toMatchObject({
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
+  });
+
+  test('.update() should call create API', (done) => {
+    r.update('id1', request)
+      .then(handler)
+      .then(() => {
+        expect(handler).toHaveBeenCalledWith(response);
+        done();
+      });
+
+    const args = fetchMocks.mock.calls[0];
+    expect(args[0]).toEqual('https://server/book/id1/');
+    expect(args[1]).toMatchObject({
+      method: 'PUT',
+      body: JSON.stringify(request),
+    });
+  });
+
+  test('.patch() should call create API', (done) => {
+    r.patch('id1', request)
+      .then(handler)
+      .then(() => {
+        expect(handler).toHaveBeenCalledWith(response);
+        done();
+      });
+
+    const args = fetchMocks.mock.calls[0];
+    expect(args[0]).toEqual('https://server/book/id1/');
+    expect(args[1]).toMatchObject({
+      method: 'PATCH',
+      body: JSON.stringify(request),
+    });
+  });
+
+  test('.delete() should call retrieve API', (done) => {
+    r.delete('id1')
+      .then(handler)
+      .then(() => {
+        expect(handler).toHaveBeenCalledWith(response);
+        done();
+      });
+
+    const args = fetchMocks.mock.calls[0];
+    expect(args[0]).toEqual('https://server/book/id1/');
+    expect(args[1]).toMatchObject({ method: 'DELETE' });
+  });
+
+  test('.getDetailAction() should call the detail API with action name', (done) => {
+    r.getDetailAction('barcode', 'id1', params)
+      .then(handler)
+      .then(() => {
+        expect(handler).toHaveBeenCalledWith(response);
+        done();
+      });
+
+    const args = fetchMocks.mock.calls[0];
+    expect(args[0]).toEqual('https://server/book/id1/barcode/?params=params');
+    expect(args[1]).toMatchObject({ method: 'GET' });
+  });
+
+  test('.postDetailAction() should call the detail API with action name', (done) => {
+    r.postDetailAction('assign', `id1`, request, params)
+      .then(handler)
+      .then(() => {
+        expect(handler).toHaveBeenCalledWith(response);
+        done();
+      });
+
+    const args = fetchMocks.mock.calls[0];
+    expect(args[0]).toEqual('https://server/book/id1/assign/?params=params');
+    expect(args[1]).toMatchObject({
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
   });
 });


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Allow non-numeric ids in the `DashResource`

- **What is the current behavior?** (You can also link to an open issue here)

The `DashResource` can only operate on numeric ids

- **What is the new behavior (if this is a feature change)?**
`DashResource` allows usage of non-numeric ids.

- **Other information**:
